### PR TITLE
fix: prevent hovered links from shifting content around

### DIFF
--- a/themes/sakura/assets/css/sakura-main.scss
+++ b/themes/sakura/assets/css/sakura-main.scss
@@ -73,6 +73,7 @@ hr {
 a {
     text-decoration: none;
     color: $color-blossom;
+    border-bottom: 2px solid transparent;
 
     &:visited {
         color: darken($color-blossom, 10%);


### PR DESCRIPTION
By always having a border on the bottom, when you hover, you don't need to change the positioning of other elements, since it's already there, so you can just switch the color from transparent to whatever color you want.

**Before:**
![opera_mn7c4hGYdC](https://user-images.githubusercontent.com/22262640/222012387-f16024d6-ca50-44aa-a3b1-b8255a4e5c36.gif)

**After:**
![opera_ahPQ4JssQn](https://user-images.githubusercontent.com/22262640/222012407-6dd0fc22-0220-46f8-b5a4-6bcbd82cbcb5.gif)